### PR TITLE
Remove unused import and use restricted S3 permissions

### DIFF
--- a/aws-greengrassv2-componentversion/aws-greengrassv2-componentversion.json
+++ b/aws-greengrassv2-componentversion/aws-greengrassv2-componentversion.json
@@ -285,7 +285,7 @@
         "greengrass:CreateComponentVersion",
         "greengrass:DescribeComponent",
         "lambda:GetFunction",
-        "s3:*"
+        "s3:GetObject"
       ]
     },
     "read": {

--- a/aws-greengrassv2-componentversion/resource-role.yaml
+++ b/aws-greengrassv2-componentversion/resource-role.yaml
@@ -30,7 +30,7 @@ Resources:
                 - "greengrass:TagResource"
                 - "greengrass:UntagResource"
                 - "lambda:GetFunction"
-                - "s3:*"
+                - "s3:GetObject"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/Translator.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/Translator.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.greengrassv2.model.DescribeComponentReque
 import software.amazon.awssdk.services.greengrassv2.model.DescribeComponentResponse;
 import software.amazon.awssdk.services.greengrassv2.model.ListComponentVersionsRequest;
 import software.amazon.awssdk.services.greengrassv2.model.ListComponentVersionsResponse;
-import software.amazon.awssdk.services.greengrassv2.model.RecipeSource;
 import software.amazon.awssdk.services.greengrassv2.model.TagResourceRequest;
 import software.amazon.awssdk.services.greengrassv2.model.UntagResourceRequest;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;


### PR DESCRIPTION
*Description of changes:*
Remove unused import and use restricted S3 permissions for `AWS::GreengrassV2::ComponentVersion`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
