### PR TITLE
fix: add required permissions

### DIFF
--- a/aws-greengrassv2-componentversion/aws-greengrassv2-componentversion.json
+++ b/aws-greengrassv2-componentversion/aws-greengrassv2-componentversion.json
@@ -295,7 +295,8 @@
     },
     "read": {
       "permissions": [
-        "greengrass:DescribeComponent"
+        "greengrass:DescribeComponent",
+        "greengrass:ListTagsForResource"
       ]
     },
     "update": {

--- a/aws-greengrassv2-componentversion/resource-role.yaml
+++ b/aws-greengrassv2-componentversion/resource-role.yaml
@@ -27,6 +27,7 @@ Resources:
                 - "greengrass:DeleteComponent"
                 - "greengrass:DescribeComponent"
                 - "greengrass:ListComponentVersions"
+                - "greengrass:ListTagsForResource"
                 - "greengrass:TagResource"
                 - "greengrass:UntagResource"
                 - "lambda:GetFunction"

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ReadHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ReadHandler.java
@@ -27,38 +27,30 @@ public class ReadHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateArnPresent)
-                .then(event -> {
-                    return proxy.initiate("AWS-GreengrassV2-ComponentVersion::Read::DescribeComponent", proxyClient, request.getDesiredResourceState(), callbackContext)
-                            .translateToServiceRequest(Translator::translateToReadRequest)
-                            .makeServiceCall((awsRequest, client) -> {
-                                try {
-                                    return client.injectCredentialsAndInvokeV2(awsRequest, client.client()::describeComponent);
-                                } catch (Exception ex) {
-                                    throw ExceptionTranslator.translateToCfnExceptionForCreatedResource(
-                                            "DescribeComponent", request.getDesiredResourceState().getArn(), ex);
-                                }
-                            }).done(describeComponentResponse -> {
-                                return ProgressEvent.progress(Translator.translateFromReadResponse(describeComponentResponse), callbackContext);
-                            });
-                })
+                .then(event -> proxy.initiate("AWS-GreengrassV2-ComponentVersion::Read::DescribeComponent", proxyClient, request.getDesiredResourceState(), callbackContext)
+                        .translateToServiceRequest(Translator::translateToReadRequest)
+                        .makeServiceCall((awsRequest, client) -> {
+                            try {
+                                return client.injectCredentialsAndInvokeV2(awsRequest, client.client()::describeComponent);
+                            } catch (Exception ex) {
+                                throw ExceptionTranslator.translateToCfnExceptionForCreatedResource(
+                                        "DescribeComponent", request.getDesiredResourceState().getArn(), ex);
+                            }
+                        }).done(describeComponentResponse -> ProgressEvent.progress(Translator.translateFromReadResponse(describeComponentResponse), callbackContext)))
                 // Read Request should list out the tags for the resource. DescribeComponent API doesn't include tags in the response
                 // For this we use the ListTagsForResource API to add tags to the output of DescribeComponentResponse from above.
                 // Tags information is only added if it's not empty.
-                .then(event -> {
-                    return proxy.initiate("AWS-GreengrassV2-ComponentVersion::Read::ListTagsForResource", proxyClient, request.getDesiredResourceState(), callbackContext)
-                            .translateToServiceRequest(Translator::translateToListTagsRequest)
-                            .makeServiceCall((awsRequest, client) -> {
-                                try {
-                                    return client.injectCredentialsAndInvokeV2(awsRequest, client.client()::listTagsForResource);
-                                } catch (Exception ex) {
-                                    throw ExceptionTranslator.translateToCfnExceptionForCreatedResource(
-                                            "ListTagsForResource", request.getDesiredResourceState().getArn(), ex);
-                                }
-                            })
-                            .done(listTagsForResourceResponse -> {
-                                return ProgressEvent.success(Translator.translateFromListTagsResponse(event.getResourceModel(), listTagsForResourceResponse), callbackContext);
-                            });
-                });
+                .then(event -> proxy.initiate("AWS-GreengrassV2-ComponentVersion::Read::ListTagsForResource", proxyClient, request.getDesiredResourceState(), callbackContext)
+                        .translateToServiceRequest(Translator::translateToListTagsRequest)
+                        .makeServiceCall((awsRequest, client) -> {
+                            try {
+                                return client.injectCredentialsAndInvokeV2(awsRequest, client.client()::listTagsForResource);
+                            } catch (Exception ex) {
+                                throw ExceptionTranslator.translateToCfnExceptionForCreatedResource(
+                                        "ListTagsForResource", request.getDesiredResourceState().getArn(), ex);
+                            }
+                        })
+                        .done(listTagsForResourceResponse -> ProgressEvent.success(Translator.translateFromListTagsResponse(event.getResourceModel(), listTagsForResourceResponse), callbackContext)));
     }
 
 }

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/Translator.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/Translator.java
@@ -93,6 +93,7 @@ public class Translator {
   /**
    * Translates resource object from sdk into a resource model
    * @param listTagsForResourceResponse the listTagsForResourceResponse
+   * @param existingModel the existing Resource Model to modify using Tags
    * @return model resource model
    */
   static ResourceModel translateFromListTagsResponse(ResourceModel existingModel, final ListTagsForResourceResponse listTagsForResourceResponse) {


### PR DESCRIPTION
*Issue #, if available:*
Create Stack with Resource was failing due to missing permissions for `ListTagsForResource`
*Description of changes:*
- Added `"greengrass:ListTagsForResource"`  permission to resource-role and resource schema
- Remove redundant returns
- Add missing param in javadoc
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
