### PR TITLE
fix: use timeoutInSeconds from model params

### DIFF
--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/CreateTranslator.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/CreateTranslator.java
@@ -70,6 +70,7 @@ public class CreateTranslator {
               .maxQueueSize(modelParams.getMaxQueueSize())
               .pinned(modelParams.getPinned())
               .statusTimeoutInSeconds(modelParams.getStatusTimeoutInSeconds())
+              .timeoutInSeconds(modelParams.getTimeoutInSeconds())
               .build();
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Translate timeoutInSeconds from Desired CFN model to GreengrassV2 CreateComponentVersion. Without this, we would pass null to the SDK and timeoutInSeconds is set to it's default value 3 at the API code.

*Description of changes:*
Use timeoutInSeconds from model params

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
