### PR TITLE
Log resource models in handlers.

### DIFF
--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/CreateHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/CreateHandler.java
@@ -33,14 +33,10 @@ public class CreateHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
+        logger.log(String.format("Creating component for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
-        logger.log(String.format("Creating component with name %s and version %s for account %s.",
-                request.getDesiredResourceState().getComponentName(),
-                request.getDesiredResourceState().getComponentVersion(), request.getAwsAccountId()));
-
-        final ResourceModel desiredResourceState = request.getDesiredResourceState();
-
-        return ProgressEvent.progress(desiredResourceState, callbackContext)
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateReadOnlyPropertiesNotPresent)
                 .then(this::validateOnlyOneRecipeSourcePresent)
                 .then(progress ->

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/DeleteHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/DeleteHandler.java
@@ -23,9 +23,8 @@ public class DeleteHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-        logger.log(String.format("Deleting component with name %s and version %s for account %s.",
-                request.getDesiredResourceState().getComponentName(),
-                request.getDesiredResourceState().getComponentVersion(), request.getAwsAccountId()));
+        logger.log(String.format("Deleting component for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress ->

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ListHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ListHandler.java
@@ -22,8 +22,8 @@ public class ListHandler extends BaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final Logger logger) {
 
-        final ResourceModel desiredResourceModel = request.getDesiredResourceState();
-        logger.log(String.format("Listing component versions for account %s.", request.getAwsAccountId()));
+        logger.log(String.format("Listing component versions for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         final ListComponentVersionsRequest listComponentVersionsRequest =
                 Translator.translateToListRequest(request, request.getNextToken());

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ReadHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/ReadHandler.java
@@ -23,10 +23,8 @@ public class ReadHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-        logger.log(String.format("Getting component version with name %s and version %s for account %s.",
-                request.getDesiredResourceState().getComponentName(),
-                request.getDesiredResourceState().getComponentVersion(), request.getAwsAccountId()));
-
+        logger.log(String.format("Reading component version for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateArnPresent)

--- a/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/UpdateHandler.java
+++ b/aws-greengrassv2-componentversion/src/main/java/software/amazon/greengrassv2/componentversion/UpdateHandler.java
@@ -29,6 +29,8 @@ public class UpdateHandler extends BaseHandlerStd {
         final Logger logger) {
 
         this.logger = logger;
+        logger.log(String.format("Updating component version for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateArnPresent)

--- a/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/CreateHandler.java
+++ b/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/CreateHandler.java
@@ -27,9 +27,8 @@ public class CreateHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-
-        logger.log(String.format("Creating deployment with deploymentName %s for account %s.",
-                request.getDesiredResourceState().getDeploymentName(), request.getAwsAccountId()));
+        logger.log(String.format("Creating deployment for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateDeploymentIdNotPresent)

--- a/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/DeleteHandler.java
+++ b/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/DeleteHandler.java
@@ -23,8 +23,8 @@ public class DeleteHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-        logger.log(String.format("Deleting deployment with deploymentId %s for account %s.",
-                request.getDesiredResourceState().getDeploymentId(), request.getAwsAccountId()));
+        logger.log(String.format("Deleting deployment for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         // Deployment should be cancelled before deleted.
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)

--- a/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/ListHandler.java
+++ b/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/ListHandler.java
@@ -27,8 +27,8 @@ public class ListHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-
-        logger.log(String.format("Listing deployment for account %s.", request.getAwsAccountId()));
+        logger.log(String.format("Listing deployments for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         final ListDeploymentsRequest listDeploymentsRequest =
                 Translator.translateToListRequest(request.getNextToken());

--- a/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/ReadHandler.java
+++ b/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/ReadHandler.java
@@ -26,8 +26,8 @@ public class ReadHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
-        logger.log(String.format("Getting deployment with deploymentId %s for account %s.",
-                request.getDesiredResourceState().getDeploymentId(), request.getAwsAccountId()));
+        logger.log(String.format("Reading deployment for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(this::validateDeploymentIdPresent)

--- a/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/UpdateHandler.java
+++ b/aws-greengrassv2-deployment/src/main/java/software/amazon/greengrassv2/deployment/UpdateHandler.java
@@ -32,6 +32,8 @@ public class UpdateHandler extends BaseHandlerStd {
             final Logger logger) {
 
         this.logger = logger;
+        logger.log(String.format("Updating deployment for account %s: %s",
+                request.getAwsAccountId(), request.getDesiredResourceState().toString()));
 
         final String deploymentArn = getDeploymentArnFromRequest(request);
 


### PR DESCRIPTION
### Description

This will allow us to check what resource model was submitted in our logs. Previously we had no way to see this which made catching bugs in handlers difficult.

New log output looks like this:
```
Creating component for account null: ResourceModel(arn=null, componentName=null, componentVersion=null, inlineRecipe=null, lambdaFunction=LambdaFunctionRecipeSource(lambdaArn=arn:aws:lambda:region:account:function:testLoggingComponentLambda:1, componentName=TestLambdaComponent, componentVersion=null, componentPlatforms=null, componentDependencies={aws.greengrass.LegacySubscriptionRouter=ComponentDependencyRequirement(versionRequirement=>=2.1.0, dependencyType=HARD)}, componentLambdaParameters=LambdaExecutionParameters(eventSources=null, maxQueueSize=1000, maxInstancesCount=100, maxIdleTimeInSeconds=60, timeoutInSeconds=300, statusTimeoutInSeconds=60, pinned=false, inputPayloadEncodingType=null, execArgs=null, environmentVariables=null, linuxProcessParams=null)), tags=null)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
